### PR TITLE
feat: add types for error response

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,14 @@
-export type NoTryResult<T> = [Error, T];
+export type NoTryResult<T, E = Error> = [E | null, T | null];
 
-export function noTry<T>(fn: () => T, handleErr: (error: Error) => void = error => null): NoTryResult<T> {
-  const result: NoTryResult<T> = [null, null];
+function noop(): void {
+  return null;
+}
+
+export function noTry<T, E = Error>(
+  fn: () => T,
+  handleErr: (error: E) => void = noop
+): NoTryResult<T, E> {
+  const result: NoTryResult<T, E> = [null, null];
   try {
     result[1] = fn();
   } catch (err) {
@@ -11,11 +18,11 @@ export function noTry<T>(fn: () => T, handleErr: (error: Error) => void = error 
   return result;
 }
 
-export async function noTryAsync<T>(
+export async function noTryAsync<T, E = Error>(
   fn: () => Promise<T>,
-  handleErr: (error: Error) => void = error => null
-): Promise<NoTryResult<T>> {
-  const result: NoTryResult<T> = [null, null];
+  handleErr: (error: E) => void = noop
+): Promise<NoTryResult<T, E>> {
+  const result: NoTryResult<T, E> = [null, null];
   try {
     result[1] = await fn();
   } catch (err) {


### PR DESCRIPTION
Adds ability to specify types for the error thrown in the try/catch.

For example, I am expecting my error to be a `RichError`.

As it stands, the types for `noTryAsync` will result in this type error:
> Property 'customData' does not exist on type 'Error'.ts(2339)

However, specifying the types for the error object allows me to safely pull additional fields:

```typescript
import { noTryAsync } from 'no-try';

class RichError extends Error {
  constructor(
    public customData: {
      moreData: string;
    }
  ) {
    super();
  }
}

const pingSite = async () => {
  throw new RichError({
    moreData: 'error from API',
  });
};

export const handler = async () => {
  const [opError, opResponse] = await noTryAsync<string, RichError>(() =>
    pingSite()
  );

  if (opError) {
    console.error(`got message: ${opError.customData.moreData}`);
  }

  if (opResponse) {
    // do something with data
  }
};
```
