### PR TITLE
feat: allow default value for result

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
-export type NoTryResult<T, E = Error> = [E | null, T | null];
+export type NoTryResult<T, E = Error> = [E | undefined, T | undefined];
 
 function noop(): void {
-  return null;
+  return undefined;
 }
 
 export function noTry<T, E = Error>(fn: () => T, handleErr: (error: E) => void = noop): NoTryResult<T, E> {
-  const result: NoTryResult<T, E> = [null, null];
+  const result: NoTryResult<T, E> = [undefined, undefined];
   try {
     result[1] = fn();
   } catch (err) {
@@ -19,7 +19,7 @@ export async function noTryAsync<T, E = Error>(
   fn: () => Promise<T>,
   handleErr: (error: E) => void = noop,
 ): Promise<NoTryResult<T, E>> {
-  const result: NoTryResult<T, E> = [null, null];
+  const result: NoTryResult<T, E> = [undefined, undefined];
   try {
     result[1] = await fn();
   } catch (err) {


### PR DESCRIPTION
Hello,

I’ve been utilizing this library for some time and recently encountered an issue. When a promise is rejected, I would like it to return a default value to allow my program to proceed. However, JavaScript does not assign a default value during destructuring when the value is null. To address this, I’ve substituted null with undefined.

I’m not certain if this project is open to pull requests, but I wanted to offer this change for consideration. Please feel free to disregard this pull request if contributions are not currently being accepted.

Best regards

```ts
import { noTryAsync } from 'no-try';

const [_, result = 'DEFAULT_VALUE'] = await noTryAsync(
    () => Promise.reject(new Error('An unexpected error occurred')), 
    err => console.log(`errorMessage: ${err.message}`)
);

// Before: null
console.log(`result: ${result}`);

// After: DEFAULT_VALUE
console.log(`result: ${result}`);
```